### PR TITLE
Release/1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 
 ## Next Version
+
+## 1.1.1
 - jcenter repository put at the end of build.graddle (conflict with google). see [issues](https://github.com/react-native-community/react-native-camera/issues/1875) in rn community
 
 # 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 
 ## Next Version
+- jcenter repository put at the end of build.graddle (conflict with google). see [issues](https://github.com/react-native-community/react-native-camera/issues/1875) in rn community
 
 # 1.1.0
 - externalContext is now a json object

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,5 @@
 buildscript {
     repositories {
-        jcenter()
         mavenCentral()
         maven {
             url 'https://maven.google.com/'
@@ -9,6 +8,7 @@ buildscript {
         flatDir {
             dirs 'libs'
         }
+        jcenter()
     }
 
     dependencies {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-snapcall",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Easy Voip Call in RN",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
the error Could not find intellij-core.jar occur in client build , can not reproduce but a workaround seems to place jcenter dependency after google one  from https://github.com/react-native-community/react-native-camera/issues/1875. 
we can see at https://github.com/react-native-community/react-native-camera/blob/master/android/build.gradle that they did the same