### PR TITLE
Fix random issue with overwritten `eventEmitter`

### DIFF
--- a/SnapcallListener.js
+++ b/SnapcallListener.js
@@ -114,7 +114,7 @@ export class SnapcallListener {
   subscription = []
 
   constructor(isIOS) {
-    var eventEmitter = isIOS ? new NativeEventEmitter(NativeModules.RNSnapcallEmitEvent) : DeviceEventEmitter;
+    const eventEmitter = isIOS ? new NativeEventEmitter(NativeModules.RNSnapcallEmitEvent) : DeviceEventEmitter;
 
     this.subscription.push(eventEmitter.addListener("onConnectionReady", onConnectionReady));
     this.subscription.push(eventEmitter.addListener("onCreated", onCreated));

--- a/SnapcallListener.js
+++ b/SnapcallListener.js
@@ -114,7 +114,7 @@ export class SnapcallListener {
   subscription = []
 
   constructor(isIOS) {
-    eventEmitter = isIOS ? new NativeEventEmitter(NativeModules.RNSnapcallEmitEvent) : DeviceEventEmitter;
+    var eventEmitter = isIOS ? new NativeEventEmitter(NativeModules.RNSnapcallEmitEvent) : DeviceEventEmitter;
 
     this.subscription.push(eventEmitter.addListener("onConnectionReady", onConnectionReady));
     this.subscription.push(eventEmitter.addListener("onCreated", onCreated));


### PR DESCRIPTION
It is Not Recommended to declare a variable without var keyword. It can accidently overwrite an existing global variable.