### PR TITLE
Improve `releaseSnapcall` method

### DIFF
--- a/Snapcall.js
+++ b/Snapcall.js
@@ -120,6 +120,6 @@ export class Snapcall {
     **/
     releaseSnapcall(){
       this.listener.release();
-      snapcallModule.releaseSnapcall();
+      return snapcallModule.releaseSnapcall();
     }
 }


### PR DESCRIPTION
`snapcallModule.releaseSnapcall()` return promise that can be rejected. To properly handle errors, we have to have this promise.