### PR TITLE
Update snapcall android and ios dependenies

### DIFF
--- a/_test/TestCall/ios/Podfile.lock
+++ b/_test/TestCall/ios/Podfile.lock
@@ -254,9 +254,9 @@ PODS:
   - React-jsinspector (0.64.1)
   - react-native-safe-area-context (3.2.0):
     - React-Core
-  - react-native-snapcall (2.1.0-beta.16):
+  - react-native-snapcall (2.2.1):
     - React
-    - Snapcall_Framework (= 5.10.1)
+    - Snapcall_Framework (= 5.10.2)
   - React-perflogger (0.64.1)
   - React-RCTActionSheet (0.64.1):
     - React-Core/RCTActionSheetHeaders (= 0.64.1)
@@ -321,7 +321,7 @@ PODS:
     - React-cxxreact (= 0.64.1)
     - React-jsi (= 0.64.1)
     - React-perflogger (= 0.64.1)
-  - Snapcall_Framework (5.10.1):
+  - Snapcall_Framework (5.10.2):
     - WebRTC_IOS (= 1.6.0-bitcode)
   - WebRTC_IOS (1.6.0-bitcode)
   - Yoga (1.14.0)
@@ -488,7 +488,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 124e8f99992490d0d13e0649d950d3e1aae06fe9
   React-jsinspector: 500a59626037be5b3b3d89c5151bc3baa9abf1a9
   react-native-safe-area-context: f0906bf8bc9835ac9a9d3f97e8bde2a997d8da79
-  react-native-snapcall: 9955e4497f7132631daeeeb7b52ac44ea6bb5b56
+  react-native-snapcall: 46d873add40bf258df23db1ae2a7c78ee5c22879
   React-perflogger: aad6d4b4a267936b3667260d1f649b6f6069a675
   React-RCTActionSheet: fc376be462c9c8d6ad82c0905442fd77f82a9d2a
   React-RCTAnimation: ba0a1c3a2738be224a08092fa7f1b444ab77d309
@@ -501,7 +501,7 @@ SPEC CHECKSUMS:
   React-RCTVibration: 4b99a7f5c6c0abbc5256410cc5425fb8531986e1
   React-runtimeexecutor: ff951a0c241bfaefc4940a3f1f1a229e7cb32fa6
   ReactCommon: bedc99ed4dae329c4fcf128d0c31b9115e5365ca
-  Snapcall_Framework: e9e4ce2da13ac46761e84f4ec25f8c3ae5cab225
+  Snapcall_Framework: 999b32c3b226d00985b55033d69a5e91e0021e52
   WebRTC_IOS: bdfe1e4d07243d889ad1b4baba187ab9014ae6ed
   Yoga: a7de31c64fe738607e7a3803e3f591a4b1df7393
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/_test/TestCall/ios/testSnapcall.xcodeproj/project.pbxproj
+++ b/_test/TestCall/ios/testSnapcall.xcodeproj/project.pbxproj
@@ -489,7 +489,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = testSnapcall/testSnapcall.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2HBLM24MWZ;
+				DEVELOPMENT_TEAM = QX8PL9Y9K2;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = testSnapcall/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -517,7 +517,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_ENTITLEMENTS = testSnapcall/testSnapcall.entitlements;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2HBLM24MWZ;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = testSnapcall/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -564,7 +564,7 @@
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "Apple Development";
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -80,7 +80,7 @@ def getGitHubRelease = { name, githubRepo = "snapcall/snapcall_sdk_android" ->
 
 dependencies {
 
-    implementation getGitHubRelease('snapcall_android_framework:2.10.0')
+    implementation getGitHubRelease('snapcall_android_framework:2.10.2')
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.squareup.okhttp3:okhttp:4.9.1'
     implementation 'org.webrtc:google-webrtc:1.0.32006'

--- a/react-native-snapcall.podspec
+++ b/react-native-snapcall.podspec
@@ -19,5 +19,5 @@ Pod::Spec.new do |s|
   s.xcconfig = { 'USER_HEADER_SEARCH_PATHS' => '"${SRCROOT}/Snapcall_Framework"' }
 
   s.dependency 'React'
-  s.dependency 'Snapcall_Framework', '5.10.1'
+  s.dependency 'Snapcall_Framework', '5.10.2'
 end


### PR DESCRIPTION
# android
2.10.2
remove manifest Permission READ_CALL_LOG and MANAGE_OWN_CALLS.
2.10.1
Fixed
fix to work on android 12.

# ios 
5.10.2
No change - Binary  update 